### PR TITLE
Updated 'describe keptnworkloadinstances' command to use an existing …

### DIFF
--- a/docs/content/en/docs/getting-started/generic-gs/_index.md
+++ b/docs/content/en/docs/getting-started/generic-gs/_index.md
@@ -141,7 +141,7 @@ You can get more detailed information about the workloads
 by describing one of the resources:
 
 ```shell
-kubectl describe keptnworkloadinstances podtato-head-podtato-head-entry -n podtato-kubectl
+kubectl describe keptnworkloadinstances  podtato-head-podtato-head-frontend -n podtato-kubectl
 ```
 
 > **Note**


### PR DESCRIPTION
Keptn workload instance 'podtato-head-podtato-head-entry' is not created by the current lifecycle toolkit example.

Replaced the command to use an existing workload instance.